### PR TITLE
Use PHPUnit\Framework\TestCase and createMock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/cache": "^1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.1",
+        "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "^2.3.1"
     },
     "autoload": {

--- a/test/CachePoolDeferTraitTest.php
+++ b/test/CachePoolDeferTraitTest.php
@@ -5,8 +5,9 @@ namespace Fig\Cache\Test;
 use Fig\Cache\CachePoolDeferTrait;
 use Prophecy\Argument;
 use Psr\Cache\CacheItemInterface;
+use PHPUnit\Framework\TestCase;
 
-class CachePoolDeferTraitTest extends \PHPUnit_Framework_TestCase
+class CachePoolDeferTraitTest extends TestCase
 {
     private $traitStub;
     private $itemStub;
@@ -14,7 +15,7 @@ class CachePoolDeferTraitTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->traitStub = $this->getMockForTrait(CachePoolDeferTrait::class);
-        $this->itemStub = $this->getMock(CacheItemInterface::class);
+        $this->itemStub = $this->createMock(CacheItemInterface::class);
     }
 
     public function testSaveSuccess()

--- a/test/KeyValidatorTest.php
+++ b/test/KeyValidatorTest.php
@@ -5,8 +5,9 @@ namespace Fig\Cache\Test;
 use Fig\Cache\Memory\MemoryPool;
 use Fig\Cache\Memory\MemoryCacheItem;
 use Fig\Cache\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class KeyValidatorTest extends \PHPUnit_Framework_TestCase
+class KeyValidatorTest extends TestCase
 {
     /** @var MemoryPool */
     protected $pool;

--- a/test/MemoryPoolTest.php
+++ b/test/MemoryPoolTest.php
@@ -3,8 +3,9 @@
 namespace Fig\Cache\Test;
 
 use Fig\Cache\Memory\MemoryPool;
+use PHPUnit\Framework\TestCase;
 
-class MemoryPoolTest extends \PHPUnit_Framework_TestCase
+class MemoryPoolTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.
 
Also, change `getMock` to `createMock`, that was [removed in PHPUnit 6](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#removed) as well.